### PR TITLE
Refactored double to BigDecimal for account balance

### DIFF
--- a/newbank/server/Account.java
+++ b/newbank/server/Account.java
@@ -10,7 +10,7 @@ public class Account {
   // allowing to enter the balance in double to make it easier to use but save for calculations
   public Account(String accountName, double openingBalance) {
     this.accountName = accountName;
-    this.openingBalance = BigDecimal.valueOf(openingBalance);
+    this.openingBalance = convertDoubleToBigDecimal(openingBalance);
   }
   
   public String toString() {
@@ -19,6 +19,11 @@ public class Account {
   
   public String getAccountName() {
     return this.accountName;
+  }
+
+  private BigDecimal convertDoubleToBigDecimal(double amount) {
+    BigDecimal bd = BigDecimal.valueOf(amount);
+    return bd.setScale(2);
   }
 
 }

--- a/newbank/server/Account.java
+++ b/newbank/server/Account.java
@@ -1,13 +1,16 @@
 package newbank.server;
 
+import java.math.BigDecimal;
+
 public class Account {
   
   private String accountName;
-  private double openingBalance;
+  private BigDecimal openingBalance;
 
+  // allowing to enter the balance in double to make it easier to use but save for calculations
   public Account(String accountName, double openingBalance) {
     this.accountName = accountName;
-    this.openingBalance = openingBalance;
+    this.openingBalance = BigDecimal.valueOf(openingBalance);
   }
   
   public String toString() {

--- a/newbank/test/NBUnit.java
+++ b/newbank/test/NBUnit.java
@@ -34,7 +34,7 @@ public class NBUnit {
     Assert(
         Objects.equals(expected, actual),
         String.format(
-            "extected:%s actual:%s",
+            "expected:%s actual:%s",
             expected == null ? "null" : expected.toString(),
             actual == null ? "null" : actual.toString()));
   }

--- a/newbank/test/ServerTestScenarios.java
+++ b/newbank/test/ServerTestScenarios.java
@@ -17,13 +17,13 @@ public class ServerTestScenarios {
         NewBank.getBank()
             .processRequest(NewBank.getBank().checkLogInDetails("Bhagy", "1"), "SHOWMYACCOUNTS");
 
-    newbank.test.NBUnit.AssertEqual("Main: 1000.0" + System.lineSeparator(), bhagy);
+    newbank.test.NBUnit.AssertEqual("Main: 1000.00" + System.lineSeparator(), bhagy);
 
     String christina =
         NewBank.getBank()
             .processRequest(
                 NewBank.getBank().checkLogInDetails("Christina", "2"), "SHOWMYACCOUNTS");
 
-    newbank.test.NBUnit.AssertEqual("Savings: 1500.0" + System.lineSeparator(), christina);
+    newbank.test.NBUnit.AssertEqual("Savings: 1500.00" + System.lineSeparator(), christina);
   }
 }


### PR DESCRIPTION
Implementation for the issue
"Stop floating point errors in calculations by no longer using double"

Changed the type of opening balance and modified the constructor so that any given double is saved as BigDecimal and can then savely be used for calculations