### PR TITLE
Specific error messages for ViewAccountTypeCommand

### DIFF
--- a/newbank/server/AccountTypeInfo.java
+++ b/newbank/server/AccountTypeInfo.java
@@ -77,6 +77,7 @@ public final class AccountTypeInfo {
     for (AccountType accType : sortedAccountInfo.keySet()) {
       sb.append(accountInfo.get(accType));
       sb.append(System.lineSeparator());
+      sb.append(System.lineSeparator());
     }
     String descriptions = sb.toString().trim();
     return descriptions;

--- a/newbank/server/AccountTypeInfo.java
+++ b/newbank/server/AccountTypeInfo.java
@@ -1,10 +1,12 @@
 package newbank.server;
 
+import java.lang.StringBuilder;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.TreeMap;
 
 import newbank.server.Account.AccountType;
 
@@ -67,6 +69,17 @@ public final class AccountTypeInfo {
     this.monthlyFee.setScale(2);
     this.term = term;
     this.otherFeatures = otherFeatures;
+  }
+
+  public static String getAllAccountTypeDescriptions() {
+    StringBuilder sb = new StringBuilder();
+    Map<AccountType, AccountTypeInfo> sortedAccountInfo = new TreeMap<AccountType, AccountTypeInfo>(accountInfo);
+    for (AccountType accType : sortedAccountInfo.keySet()) {
+      sb.append(accountInfo.get(accType));
+      sb.append(System.lineSeparator());
+    }
+    String descriptions = sb.toString().trim();
+    return descriptions;
   }
   
   public static AccountTypeInfo getAccountTypeInfo(AccountType type) {

--- a/newbank/server/Commands/ViewAccountTypeCommand.java
+++ b/newbank/server/Commands/ViewAccountTypeCommand.java
@@ -3,6 +3,7 @@ package newbank.server.Commands;
 import newbank.server.Account;
 import newbank.server.AccountTypeInfo;
 
+
 import java.util.regex.Matcher;
 
 public class ViewAccountTypeCommand extends NewBankCommand {
@@ -22,11 +23,14 @@ public class ViewAccountTypeCommand extends NewBankCommand {
 
     Account.AccountType accountType = getAccountType(param);
 
+    if (param.getCommandArgument().isEmpty()) {
+      return NewBankCommandResponse.succeeded(AccountTypeInfo.getAllAccountTypeDescriptions().toString());
+    }
     if (accountType == Account.AccountType.NONE)
-      return NewBankCommandResponse.invalidRequest("FAIL");
+      return NewBankCommandResponse.invalidRequest("Invalid account type.");
 
     AccountTypeInfo info = AccountTypeInfo.getAccountTypeInfo(accountType);
-    if (info == null) return NewBankCommandResponse.failed("FAIL");
+    if (info == null) return NewBankCommandResponse.failed("Could not retrieve account info.");
 
     return NewBankCommandResponse.succeeded(info.toString());
   }

--- a/protocol.txt
+++ b/protocol.txt
@@ -33,6 +33,9 @@ Returns list of all user commands.
 LOGOUT
 Disconnects from server and exits client application.
 
+VIEWACCOUNTTYPE
+Returns details of all account types.
+
 VIEWACCOUNTTYPE <Type>
 e.g. VIEWACCOUNTTYPE "Cash ISA"
 Returns details of account type or FAIL.


### PR DESCRIPTION
Added custom responses to different command arguments for the following conditions:
If no argument/whitespace only argument is given - returns all account information sorted by order of entry in accountInfo;
If invalid argument is given (i.e. doesn't match an account type);
If server fails to return account info.

Also added method that returns account type information as a single String.