### PR TITLE
HELP/COMMANDS now prints command names only, must use <COMMAND> -?, -…

### DIFF
--- a/newbank/server/Commands/NewAccountCommand.java
+++ b/newbank/server/Commands/NewAccountCommand.java
@@ -28,17 +28,17 @@ public class NewAccountCommand extends NewBankCommand {
     var args = NewAccountCommandArgument.parse(param);
 
     if (args == null)
-      return NewBankCommandResponse.invalidRequest(
+      return NewBankCommandResponse.invalidRequest(this,
           "FAIL: Account type must be specified. Accepted account types: "
               + AccountTypeInfo.listAllAccountTypesCommaDelimited()
               + ".");
 
     // Previously this was tested in NewBankArgument
     if (param.getCustomer().hasAccount(args.getAccountName()))
-      return NewBankCommandResponse.invalidRequest("FAIL: Please choose a unique name.");
+      return NewBankCommandResponse.invalidRequest(this, "FAIL: Please choose a unique name.");
 
     if (args.getCurrency() == null)
-      return NewBankCommandResponse.failed(
+      return NewBankCommandResponse.failed(this,
           "FAIL: Currency not allowed. Accepted currencies: " + Currency.listAllCurrencies() + ".");
 
     // requested currency is allowed
@@ -48,7 +48,7 @@ public class NewAccountCommand extends NewBankCommand {
             new Account(args.getAccountType(), args.getAccountName(), 0, args.getCurrency()));
 
     return (param.getCustomer().hasAccount(args.getAccountType(), args.getAccountName()))
-        ? NewBankCommandResponse.succeeded(
+        ? NewBankCommandResponse.succeeded(this,
             "SUCCESS: Opened account TYPE:\""
                 + args.getAccountType().toString()
                 + "\" NAME:\""
@@ -56,7 +56,7 @@ public class NewAccountCommand extends NewBankCommand {
                 + "\""
                 + " CURRENCY:"
                 + args.getCurrency().name())
-        : NewBankCommandResponse.failed("FAIL: Account could not be opened. Please try again.");
+        : NewBankCommandResponse.failed(this, "FAIL: Account could not be opened. Please try again.");
   }
 
   private static class NewAccountCommandArgument {

--- a/newbank/server/Commands/NewBankCommandResponse.java
+++ b/newbank/server/Commands/NewBankCommandResponse.java
@@ -13,7 +13,7 @@ public class NewBankCommandResponse {
     HELP
   }
   
-  public static NewBankCommandResponse EMPTY = new NewBankCommandResponse(null, ResponseType.EMPTY, "");
+  public static final NewBankCommandResponse EMPTY = new NewBankCommandResponse(null, ResponseType.EMPTY, "");
 
   public static NewBankCommandResponse succeeded(INewBankCommand command, String description) {
     return new NewBankCommandResponse(command, ResponseType.SUCCEEDED, description);

--- a/newbank/server/Commands/NewBankCommandResponse.java
+++ b/newbank/server/Commands/NewBankCommandResponse.java
@@ -1,31 +1,40 @@
 package newbank.server.Commands;
 
 public class NewBankCommandResponse {
+  private final INewBankCommand command;
   private final ResponseType type;
   private String description;
 
   public enum ResponseType {
+    EMPTY,
     SUCCEEDED,
     FAILED,
     INVALIDREQUEST,
     HELP
   }
+  
+  public static NewBankCommandResponse EMPTY = new NewBankCommandResponse(null, ResponseType.EMPTY, "");
 
-  public static NewBankCommandResponse succeeded(String description) {
-    return new NewBankCommandResponse(ResponseType.SUCCEEDED, description);
+  public static NewBankCommandResponse succeeded(INewBankCommand command, String description) {
+    return new NewBankCommandResponse(command, ResponseType.SUCCEEDED, description);
   }
 
-  public static NewBankCommandResponse failed(String description) {
-    return new NewBankCommandResponse(ResponseType.FAILED, description);
+  public static NewBankCommandResponse failed(INewBankCommand command, String description) {
+    return new NewBankCommandResponse(command, ResponseType.FAILED, description);
   }
 
-  public static NewBankCommandResponse invalidRequest(String description) {
-    return new NewBankCommandResponse(ResponseType.INVALIDREQUEST, description);
+  public static NewBankCommandResponse invalidRequest(INewBankCommand command, String description) {
+    return new NewBankCommandResponse(command, ResponseType.INVALIDREQUEST, description);
   }
-
-  public NewBankCommandResponse(ResponseType type, String description) {
+  
+  public static NewBankCommandResponse help(INewBankCommand command) {
+    return new NewBankCommandResponse(command, ResponseType.HELP, "");
+  }
+  
+  protected NewBankCommandResponse(INewBankCommand command, ResponseType type, String description) {
     this.type = type;
     this.description = description;
+    this.command = command;
   }
 
   public ResponseType getType() {
@@ -34,5 +43,9 @@ public class NewBankCommandResponse {
 
   public String getDescription() {
     return description;
+  }
+  
+  public INewBankCommand getCommand() {
+    return command;
   }
 }

--- a/newbank/server/Commands/NewBankCommandResponse.java
+++ b/newbank/server/Commands/NewBankCommandResponse.java
@@ -5,24 +5,25 @@ public class NewBankCommandResponse {
   private String description;
 
   public enum ResponseType {
-    Succeeded,
-    Failed,
-    InvalidRequest
+    SUCCEEDED,
+    FAILED,
+    INVALIDREQUEST,
+    HELP
   }
 
   public static NewBankCommandResponse succeeded(String description) {
-    return new NewBankCommandResponse(ResponseType.Succeeded, description);
+    return new NewBankCommandResponse(ResponseType.SUCCEEDED, description);
   }
 
   public static NewBankCommandResponse failed(String description) {
-    return new NewBankCommandResponse(ResponseType.Failed, description);
+    return new NewBankCommandResponse(ResponseType.FAILED, description);
   }
 
   public static NewBankCommandResponse invalidRequest(String description) {
-    return new NewBankCommandResponse(ResponseType.InvalidRequest, description);
+    return new NewBankCommandResponse(ResponseType.INVALIDREQUEST, description);
   }
 
-  protected NewBankCommandResponse(ResponseType type, String description) {
+  public NewBankCommandResponse(ResponseType type, String description) {
     this.type = type;
     this.description = description;
   }

--- a/newbank/server/Commands/ShowMyAccountsCommand.java
+++ b/newbank/server/Commands/ShowMyAccountsCommand.java
@@ -14,6 +14,6 @@ public class ShowMyAccountsCommand extends NewBankCommand {
 
   @Override
   public NewBankCommandResponse run(NewBankCommandParameter param) {
-    return NewBankCommandResponse.succeeded(param.getCustomer().accountsToString());
+    return NewBankCommandResponse.succeeded(this, param.getCustomer().accountsToString());
   }
 }

--- a/newbank/server/Commands/TransferCommand.java
+++ b/newbank/server/Commands/TransferCommand.java
@@ -26,44 +26,44 @@ public class TransferCommand extends NewBankCommand {
     // TODO make / a forbidden character when naming new accounts
     String[] request = input.split("/");
     if (request.length != 3) {
-      return NewBankCommandResponse.invalidRequest("Not enough arguments. Please try again.");
+      return NewBankCommandResponse.invalidRequest(this, "Not enough arguments. Please try again.");
     }
     Account debitedAccount = customer.getAccountFromName(request[0].replaceAll("\"", ""));
     Account creditedAccount = customer.getAccountFromName(request[1].replaceAll("\"", ""));
 
     if (debitedAccount == null) {
-      return NewBankCommandResponse.failed(
+      return NewBankCommandResponse.failed(this,
           "Account to be debited does not exist. Please try again.");
     }
     if (creditedAccount == null) {
-      return NewBankCommandResponse.failed(
+      return NewBankCommandResponse.failed(this,
           "Account to be credited does not exist. Please try again.");
     }
     if (request[0].equals(request[1])) {
-      return NewBankCommandResponse.failed(
+      return NewBankCommandResponse.failed(this,
           "The debiting and crediting accounts are the same. Please try again.");
     }
 
     if (!debitedAccount.getCurrency().equals(creditedAccount.getCurrency())) {
-      return NewBankCommandResponse.failed(
+      return NewBankCommandResponse.failed(this,
           "The currency of each account is not the same. Please try again.");
     }
 
     if (!validAmount(request[2])) {
-      return NewBankCommandResponse.failed("Amount is invalid. Please try again.");
+      return NewBankCommandResponse.failed(this, "Amount is invalid. Please try again.");
     }
 
     BigDecimal amount = convertDoubleToBigDecimal(Double.parseDouble(request[2]));
 
     if (debitedAccount.getBalance().compareTo(amount) < 0) {
-      return NewBankCommandResponse.failed(
+      return NewBankCommandResponse.failed(this,
           "Not enough funds in account to be debited. Please try again.");
     }
 
     debitedAccount.moneyOut(amount);
     creditedAccount.moneyIn(amount);
 
-    return NewBankCommandResponse.succeeded(
+    return NewBankCommandResponse.succeeded(this,
         "Transfer successful." + System.lineSeparator() + "The balance of "
             + creditedAccount.getAccountName()
             + " is now "

--- a/newbank/server/Commands/ViewAccountTypeCommand.java
+++ b/newbank/server/Commands/ViewAccountTypeCommand.java
@@ -24,15 +24,15 @@ public class ViewAccountTypeCommand extends NewBankCommand {
     Account.AccountType accountType = getAccountType(param);
 
     if (param.getCommandArgument().isEmpty()) {
-      return NewBankCommandResponse.succeeded(AccountTypeInfo.getAllAccountTypeDescriptions().toString());
+      return NewBankCommandResponse.succeeded(this, AccountTypeInfo.getAllAccountTypeDescriptions().toString());
     }
     if (accountType == Account.AccountType.NONE)
-      return NewBankCommandResponse.invalidRequest("Invalid account type.");
+      return NewBankCommandResponse.invalidRequest(this, "Invalid account type.");
 
     AccountTypeInfo info = AccountTypeInfo.getAccountTypeInfo(accountType);
-    if (info == null) return NewBankCommandResponse.failed("Could not retrieve account info.");
+    if (info == null) return NewBankCommandResponse.failed(this, "Could not retrieve account info.");
 
-    return NewBankCommandResponse.succeeded(info.toString());
+    return NewBankCommandResponse.succeeded(this, info.toString());
   }
 
   public static Account.AccountType getAccountType(NewBankCommandParameter param) {

--- a/newbank/server/NewBankClientHandler.java
+++ b/newbank/server/NewBankClientHandler.java
@@ -159,7 +159,7 @@ public class NewBankClientHandler extends Thread {
     private static String getHelpInfo(INewBankCommand command) {
       return (command != null)
              ? command.getCommandName() + " " + command.getDescription()
-             : "Unrecognized command";
+             : "Unrecognised command";
     }
 
     private void printMenu() {

--- a/newbank/test/ServerTestScenarios.java
+++ b/newbank/test/ServerTestScenarios.java
@@ -222,8 +222,6 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "Account to be credited does not exist. Please try again."
-            + System.lineSeparator()
-            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString);
 
@@ -233,8 +231,6 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "Account to be debited does not exist. Please try again."
-            + System.lineSeparator()
-            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString2);
 
@@ -244,8 +240,6 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "The debiting and crediting accounts are the same. Please try again."
-            + System.lineSeparator()
-            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString3);
 
@@ -254,8 +248,6 @@ public class ServerTestScenarios {
         runServerCommand(userName, password, "TRANSFER Saving 1/Checking 1/-100");
     AssertEqual(
         initialResponse + "Amount is invalid. Please try again."
-            + System.lineSeparator()
-            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString4);
 
@@ -264,8 +256,6 @@ public class ServerTestScenarios {
         runServerCommand(userName, password, "TRANSFER \"Saving 1\"/\"Checking 1\"/t");
     AssertEqual(
         initialResponse + "Amount is invalid. Please try again."
-            + System.lineSeparator()
-            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString5);
 
@@ -291,8 +281,6 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "Not enough funds in account to be debited. Please try again."
-            + System.lineSeparator()
-            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString);
   }

--- a/newbank/test/ServerTestScenarios.java
+++ b/newbank/test/ServerTestScenarios.java
@@ -7,6 +7,7 @@ import newbank.server.Commands.ShowMyAccountsCommand;
 import newbank.server.Commands.ViewAccountTypeCommand;
 import newbank.server.NewBank;
 
+import java.util.Map;
 import java.util.Objects;
 
 import static newbank.test.NBUnit.AssertEqual;
@@ -113,7 +114,7 @@ public class ServerTestScenarios {
     NewBankCommandResponse response =
         command.run(NewBankCommandParameter.create(id, "NEWACCOUNT \"Savings Account\" Saving"));
 
-    AssertEqual(NewBankCommandResponse.ResponseType.Succeeded, response.getType());
+    AssertEqual(NewBankCommandResponse.ResponseType.SUCCEEDED, response.getType());
 
     NBUnit.AssertEqual(
         "SUCCESS: Opened account TYPE:\"Savings Account\" NAME:\"Saving\" CURRENCY:GBP",
@@ -130,7 +131,7 @@ public class ServerTestScenarios {
         command.run(
             NewBankCommandParameter.create(id, "NEWACCOUNT \"Savings Account\" Travel eur"));
 
-    AssertEqual(NewBankCommandResponse.ResponseType.Succeeded, response.getType());
+    AssertEqual(NewBankCommandResponse.ResponseType.SUCCEEDED, response.getType());
 
     NBUnit.AssertEqual(
         "SUCCESS: Opened account TYPE:\"Savings Account\" NAME:\"Travel\" CURRENCY:EUR",
@@ -221,6 +222,8 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "Account to be credited does not exist. Please try again."
+            + System.lineSeparator()
+            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString);
 
@@ -230,6 +233,8 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "Account to be debited does not exist. Please try again."
+            + System.lineSeparator()
+            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString2);
 
@@ -239,6 +244,8 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "The debiting and crediting accounts are the same. Please try again."
+            + System.lineSeparator()
+            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString3);
 
@@ -246,20 +253,29 @@ public class ServerTestScenarios {
     String outputString4 =
         runServerCommand(userName, password, "TRANSFER Saving 1/Checking 1/-100");
     AssertEqual(
-        initialResponse + "Amount is invalid. Please try again." + System.lineSeparator(),
+        initialResponse + "Amount is invalid. Please try again."
+            + System.lineSeparator()
+            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
+            + System.lineSeparator(),
         outputString4);
 
     // Test 5
     String outputString5 =
         runServerCommand(userName, password, "TRANSFER \"Saving 1\"/\"Checking 1\"/t");
     AssertEqual(
-        initialResponse + "Amount is invalid. Please try again." + System.lineSeparator(),
+        initialResponse + "Amount is invalid. Please try again."
+            + System.lineSeparator()
+            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
+            + System.lineSeparator(),
         outputString5);
 
     // Test 6
     String outputString6 = runServerCommand(userName, password, "TRANSFER Saving 1/Checking 1");
     AssertEqual(
-        initialResponse + "Not enough arguments. Please try again." + System.lineSeparator(),
+        initialResponse + "Not enough arguments. Please try again."
+            + System.lineSeparator()
+            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
+            + System.lineSeparator(),
         outputString6);
   }
 
@@ -275,6 +291,8 @@ public class ServerTestScenarios {
     AssertEqual(
         initialResponse
             + "Not enough funds in account to be debited. Please try again."
+            + System.lineSeparator()
+            + System.lineSeparator() + "TRANSFER " + commandDescriptions.get("TRANSFER")
             + System.lineSeparator(),
         outputString);
   }
@@ -300,25 +318,20 @@ public class ServerTestScenarios {
 
   // todo: refactor to improve maintainability
   final String commandList =
-      "SHOWMYACCOUNTS -> Lists all of your active accounts."
+      "> SHOWMYACCOUNTS"
           + System.lineSeparator()
-          + "NEWACCOUNT <account type> <optional: account name> <optional: currency> "
+          + "> NEWACCOUNT"
           + System.lineSeparator()
-          + "-> Creates a new account of specified type e.g. NEWACCOUNT \"Savings Account\" \"my savings\" EUR. "
+          + "> VIEWACCOUNTTYPE"
           + System.lineSeparator()
-          + "   Standard currency is GBP, please specify an account name and currency to create an account with a different currency."
+          + "> TRANSFER"
           + System.lineSeparator()
-          + "VIEWACCOUNTTYPE <account type> -> Prints details of specified account type e.g. VIEWACCOUNTTYPE \"Cash ISA\"."
+          + "> HELP / COMMANDS -> Show command list."
           + System.lineSeparator()
-          + "TRANSFER <Account Name>/<Account Name>/<Amount>"
+          + "> LOGOUT -> Ends the current banking session and logs you out of NewBank."
           + System.lineSeparator()
-          + "-> Transfer from the first listed account into the second."
           + System.lineSeparator()
-          + "   To format add \"/\" between accounts and amount eg TRANSFER account 1/account 2/100.0."
-          + System.lineSeparator()
-          + "HELP / COMMANDS -> Show command list."
-          + System.lineSeparator()
-          + "LOGOUT -> Ends the current banking session and logs you out of NewBank."
+          + "Append -?, -h or -help for command description e.g. \"NEWACCOUNT -help\"."
           + System.lineSeparator();
 
   final String initialResponse =
@@ -334,4 +347,24 @@ public class ServerTestScenarios {
           + "COMMANDS:"
           + System.lineSeparator()
           + commandList;
+  
+  final Map<String, String> commandDescriptions = Map.of(
+      "SHOWMYACCOUNTS",
+      "-> Lists all of your active accounts.",
+      
+      "NEWACCOUNT",
+      "<account type> <optional: account name> <optional: currency> "
+          + System.lineSeparator()
+          + "-> Creates a new account of specified type e.g. NEWACCOUNT \"Savings Account\" \"my savings\" EUR. "
+          + System.lineSeparator()
+          + "   Standard currency is GBP, please specify an account name and currency to create an account with a different currency.",
+      
+      "VIEWACCOUNTTYPE",
+      "<account type> -> Prints details of specified account type e.g. VIEWACCOUNTTYPE \\\"Cash ISA\\\".",
+      
+      "TRANSFER",
+      "<Account Name>/<Account Name>/<Amount>" + System.lineSeparator()
+          + "-> Transfer from the first listed account into the second." + System.lineSeparator()
+          + "   To format add \"/\" between accounts and amount eg TRANSFER account 1/account 2/100.0.");
+      
 }

--- a/protocol.txt
+++ b/protocol.txt
@@ -1,6 +1,6 @@
 This document details the protocol for interacting with the NewBank server.
 
-A customer enters the command below and sees the messages returned.  Append -?, -h or -help for command description e.g. \"NEWACCOUNT -help\".
+A customer enters the command below and sees the messages returned.  Append -?, -h or -help for command description e.g. "NEWACCOUNT -help".
 
 SHOWMYACCOUNTS
 Returns a list of all the customers accounts along with their current balance

--- a/protocol.txt
+++ b/protocol.txt
@@ -1,10 +1,10 @@
 This document details the protocol for interacting with the NewBank server.
 
-A customer enters the command below and sees the messages returned
+A customer enters the command below and sees the messages returned.  Append -?, -h or -help for command description e.g. \"NEWACCOUNT -help\".
 
 SHOWMYACCOUNTS
 Returns a list of all the customers accounts along with their current balance
-e.g. Main: 1000.00 GBP
+e.g. Current Account: Main: 1000.00 GBP
 
 NEWACCOUNT <Type> <Name (optional)> <Currency (optional)>
 e.g. NEWACCOUNT "Cash ISA" "Savings 1" EUR


### PR DESCRIPTION
…h, -help for command description

Precise control of the command help.

Problem:
Showing all the commands and their descriptions at the same time might look verbose.

Solution:
1. The menu or COMMANDS command only show the names of the commands.
2. The description of a command is shown only when an invalid parameter is typed by a user.
