### PR TITLE
Standard messages ch2333

### DIFF
--- a/newbank/server/Commands/NewAccountCommand.java
+++ b/newbank/server/Commands/NewAccountCommand.java
@@ -30,7 +30,7 @@ public class NewAccountCommand extends NewBankCommand {
 
     if (args == null) {
       response.invalidRequest(
-          "FAIL: Account type must be specified. Accepted account types: "
+          "Account type must be specified. Accepted account types: "
               + AccountTypeInfo.listAllAccountTypesCommaDelimited()
               + ".");
       return;
@@ -38,13 +38,13 @@ public class NewAccountCommand extends NewBankCommand {
 
     // Previously this was tested in NewBankArgument
     if (request.getCustomer().hasAccount(args.getAccountName())) {
-      response.invalidRequest("FAIL: Please choose a unique name.");
+      response.invalidRequest("Please choose a unique name.");
       return;
     }
 
     if (args.getCurrency() == null) {
       response.failed(
-          "FAIL: Currency not allowed. Accepted currencies: " + Currency.listAllCurrencies() + ".");
+          "Currency not allowed. Accepted currencies: " + Currency.listAllCurrencies() + ".");
       return;
     }
 
@@ -54,7 +54,7 @@ public class NewAccountCommand extends NewBankCommand {
           System.lineSeparator() +
           "Do you want to continue?";
       if (!response.confirm(confirmationMessage)) {
-        response.failed("FAIL: No new account created.");
+        response.failed("No new account created.");
         return;
       }
     }
@@ -75,7 +75,7 @@ public class NewAccountCommand extends NewBankCommand {
               + "\""
               + " CURRENCY:"
               + args.getCurrency().name());
-    else response.failed("FAIL: Account could not be opened. Please try again.");
+    else response.failed("Account could not be opened. Please try again.");
   }
 
   private static class NewAccountCommandArgument {

--- a/newbank/server/Commands/NewAccountCommand.java
+++ b/newbank/server/Commands/NewAccountCommand.java
@@ -68,7 +68,7 @@ public class NewAccountCommand extends NewBankCommand {
 
     if (request.getCustomer().hasAccount(args.getAccountType(), args.getAccountName()))
       response.succeeded(
-          "SUCCESS: Opened account TYPE:\""
+          "Opened account TYPE:\""
               + args.getAccountType().toString()
               + "\" NAME:\""
               + args.getAccountName()

--- a/newbank/server/Commands/NewBankCommandResponse.java
+++ b/newbank/server/Commands/NewBankCommandResponse.java
@@ -48,11 +48,11 @@ public class NewBankCommandResponse {
   }
 
   public NewBankCommandResponse failed(String description) {
-    return setState(ResponseType.FAILED, description);
+    return setState(ResponseType.FAILED, "FAIL: " + description);
   }
 
   public NewBankCommandResponse invalidRequest(String description) {
-    return setState(ResponseType.INVALIDREQUEST, description);
+    return setState(ResponseType.INVALIDREQUEST, "FAIL: " + description);
   }
 
   public NewBankCommandResponse help(String description) {

--- a/newbank/server/Commands/NewBankCommandResponse.java
+++ b/newbank/server/Commands/NewBankCommandResponse.java
@@ -21,7 +21,8 @@ public class NewBankCommandResponse {
     SUCCEEDED,
     FAILED,
     INVALIDREQUEST,
-    HELP
+    HELP,
+    VIEWED
   }
 
   public static final NewBankCommandResponse EMPTY =
@@ -29,6 +30,10 @@ public class NewBankCommandResponse {
 
   public static NewBankCommandResponse createSucceeded(String description) {
     return new NewBankCommandResponse().succeeded(description);
+  }
+
+  public static NewBankCommandResponse createViewed(String description) {
+    return new NewBankCommandResponse().viewed(description);
   }
 
   public static NewBankCommandResponse createFailed(String description) {
@@ -44,7 +49,11 @@ public class NewBankCommandResponse {
   }
 
   public NewBankCommandResponse succeeded(String description) {
-    return setState(ResponseType.SUCCEEDED, description);
+    return setState(ResponseType.SUCCEEDED, "SUCCESS: " + description);
+  }
+
+  public NewBankCommandResponse viewed(String description) {
+    return setState(ResponseType.VIEWED, description);
   }
 
   public NewBankCommandResponse failed(String description) {

--- a/newbank/server/Commands/PayCommand.java
+++ b/newbank/server/Commands/PayCommand.java
@@ -25,33 +25,33 @@ public class PayCommand extends NewBankCommand {
 
     var args = PayArguments.parse(request);
     if (args == null) {
-      response.invalidRequest("FAIL");
+      response.invalidRequest("No arguments entered. Please enter account number and amount.");
       return;
     }
 
     var customer = request.getCustomer();
 
     if (args.amount.doubleValue() <= 0) {
-      response.invalidRequest("FAIL");
+      response.invalidRequest("Payment of a negative amount is not possible.");
       return;
     }
 
     Account debitedAccount = findDebitedAccount(customer, response);
 
     if (debitedAccount == null || debitedAccount.getBalance().compareTo(args.amount) < 0) {
-      response.invalidRequest("FAIL");
+      response.invalidRequest("The debited account was not found or its balance it too low.");
       return;
     }
 
     Account creditedAccount = NewBank.getBank().getAccounts().get(args.accountNumber);
 
     if (creditedAccount == null || creditedAccount == debitedAccount) {
-      response.invalidRequest("FAIL");
+      response.invalidRequest("The credited account is invalid.");
       return;
     }
 
     if (!debitedAccount.getCurrency().equals(creditedAccount.getCurrency())) {
-      response.invalidRequest("FAIL");
+      response.invalidRequest("The currencies of the chosen accounts do not match.");
       return;
     }
 
@@ -69,7 +69,7 @@ public class PayCommand extends NewBankCommand {
             args.amount.toString());
 
     if (!response.confirm(confirmationMessage)) {
-      response.invalidRequest("FAIL");
+      response.invalidRequest("Transaction not confirmed.");
       return;
     }
 
@@ -77,7 +77,7 @@ public class PayCommand extends NewBankCommand {
     creditedAccount.moneyIn(args.amount);
 
     response.succeeded(
-        "PAY Successful"
+        "SUCCESS: PAY Successful"
             + System.lineSeparator()
             + String.format(
                 "You have made a payment of £%s to the Account(Number:%03d Type:[%s] Name:\"%s\")",

--- a/newbank/server/Commands/PayCommand.java
+++ b/newbank/server/Commands/PayCommand.java
@@ -77,7 +77,7 @@ public class PayCommand extends NewBankCommand {
     creditedAccount.moneyIn(args.amount);
 
     response.succeeded(
-        "SUCCESS: PAY Successful"
+        "PAY Successful"
             + System.lineSeparator()
             + String.format(
                 "You have made a payment of £%s to the Account(Number:%03d Type:[%s] Name:\"%s\")",

--- a/newbank/server/Commands/ShowMyAccountsCommand.java
+++ b/newbank/server/Commands/ShowMyAccountsCommand.java
@@ -14,6 +14,6 @@ public class ShowMyAccountsCommand extends NewBankCommand {
 
   @Override
   public void run(NewBankCommandRequest request, NewBankCommandResponse response) {
-    response.succeeded(request.getCustomer().accountsToString());
+    response.viewed(request.getCustomer().accountsToString());
   }
 }

--- a/newbank/server/Commands/ShowMyLoansCommand.java
+++ b/newbank/server/Commands/ShowMyLoansCommand.java
@@ -14,6 +14,6 @@ public class ShowMyLoansCommand extends NewBankCommand {
 
   @Override
   public void run(NewBankCommandRequest request, NewBankCommandResponse response) {
-    response.succeeded(request.getCustomer().loansToString());
+    response.viewed(request.getCustomer().loansToString());
   }
 }

--- a/newbank/server/Commands/ViewAccountTypeCommand.java
+++ b/newbank/server/Commands/ViewAccountTypeCommand.java
@@ -38,7 +38,7 @@ public class ViewAccountTypeCommand extends NewBankCommand {
       return;
     }
 
-    response.succeeded(info.toString());
+    response.viewed(info.toString());
   }
 
   public static Account.AccountType getAccountType(NewBankCommandRequest param) {

--- a/newbank/server/Commands/ViewOffersCommand.java
+++ b/newbank/server/Commands/ViewOffersCommand.java
@@ -76,7 +76,7 @@ public class ViewOffersCommand extends NewBankCommand {
     List<Offer> sortedOffers = sortOffers(matchingOffers);
     
     if (matchingOffers.size() > 0) {
-      response.succeeded(printOffers(sortedOffers));
+      response.viewed(printOffers(sortedOffers));
     } else {
       response.failed("No matching offers found.");
     }

--- a/newbank/server/Commands/ViewOffersCommand.java
+++ b/newbank/server/Commands/ViewOffersCommand.java
@@ -78,7 +78,7 @@ public class ViewOffersCommand extends NewBankCommand {
     if (matchingOffers.size() > 0) {
       response.succeeded(printOffers(sortedOffers));
     } else {
-      response.failed("FAIL: No matching offers found.");
+      response.failed("No matching offers found.");
     }
   }
   

--- a/newbank/server/NewBankClientHandler.java
+++ b/newbank/server/NewBankClientHandler.java
@@ -16,8 +16,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static newbank.server.Commands.NewBankCommandResponse.createInvalidRequest;
-import static newbank.server.Commands.NewBankCommandResponse.createSucceeded;
+import static newbank.server.Commands.NewBankCommandResponse.*;
 
 public class NewBankClientHandler extends Thread {
 
@@ -137,10 +136,10 @@ public class NewBankClientHandler extends Thread {
       switch (request.getCommandName()) {
         case "LOGOUT":
           return new DispatchResult(
-              null, createSucceeded("Log out successful. Goodbye " + request.getId().getKey()));
+              null, createViewed("Log out successful. Goodbye " + request.getId().getKey()));
         case "COMMANDS":
         case "HELP":
-          return new DispatchResult(null, createSucceeded(formatCommands()));
+          return new DispatchResult(null, createViewed(formatCommands()));
         default:
           return runCommand(request);
       }
@@ -164,7 +163,7 @@ public class NewBankClientHandler extends Thread {
       } else if (request.getCommandName().isBlank()) {
         return new DispatchResult(null, NewBankCommandResponse.EMPTY);
       } else {
-        return new DispatchResult(null, createInvalidRequest("FAIL: Invalid command."));
+        return new DispatchResult(null, createInvalidRequest("Invalid command."));
       }
     }
 

--- a/newbank/test/ServerTestScenarios.java
+++ b/newbank/test/ServerTestScenarios.java
@@ -102,7 +102,7 @@ public class ServerTestScenarios {
             + System.lineSeparator()
             + "Do you finish the feature? [Y]es/[N]o :"
             + System.lineSeparator()
-            + "Good luck!"
+            + "SUCCESS: Good luck!"
             + System.lineSeparator(),
         out.toString());
   }
@@ -506,7 +506,7 @@ public class ServerTestScenarios {
     String outputString = runServerCommand("John", "3", "MOVE 321.62 \"Saving 1\" \"Checking 1\"");
     AssertEqual(
         initialResponse
-            + "Move successful."
+            + "SUCCESS: Move successful."
             + System.lineSeparator()
             + "The balance of Checking 1 is now 571.62GBP."
             + System.lineSeparator()

--- a/newbank/test/ServerTestScenarios.java
+++ b/newbank/test/ServerTestScenarios.java
@@ -174,7 +174,7 @@ public class ServerTestScenarios {
 
     // validate
     AssertEqual(
-        "PAY Successful"
+        "SUCCESS: PAY Successful"
             + System.lineSeparator()
             + "You have made a payment of £100.00 to the Account(Number:002 Type:[Savings Account] Name:\"Savings 1\")"
             + System.lineSeparator()
@@ -196,7 +196,7 @@ public class ServerTestScenarios {
     NewBankCommandResponse response = runPay(bhagy, "PAY 2 100", "N");
 
     // validate
-    AssertEqual("FAIL", response.getDescription());
+    AssertEqual("FAIL: Transaction not confirmed.", response.getDescription());
 
     validateShowMyAccount(bhagy, "Current Account", 1, "Main 1", 1000);
     validateShowMyAccount(christina, "Savings Account", 2, "Savings 1", 1500);
@@ -216,7 +216,7 @@ public class ServerTestScenarios {
 
     // validate
     AssertEqual(
-        "PAY Successful"
+        "SUCCESS: PAY Successful"
             + System.lineSeparator()
             + "You have made a payment of £100.00 to the Account(Number:002 Type:[Savings Account] Name:\"Savings 1\")"
             + System.lineSeparator()
@@ -433,7 +433,7 @@ public class ServerTestScenarios {
         runServerCommand(userName, password, "MOVE 200 \"Checking 1\" \"Checking 2\"");
     AssertEqual(
         initialResponse
-            + "Account to be credited does not exist. Please try again."
+            + "FAIL: Account to be credited does not exist. Please try again."
             + System.lineSeparator(),
         outputString);
 
@@ -442,7 +442,7 @@ public class ServerTestScenarios {
         runServerCommand(userName, password, "MOVE 200 \"Checking 2\" \"Checking 1\"");
     AssertEqual(
         initialResponse
-            + "Account to be debited does not exist. Please try again."
+            + "FAIL: Account to be debited does not exist. Please try again."
             + System.lineSeparator(),
         outputString2);
 
@@ -451,7 +451,7 @@ public class ServerTestScenarios {
         runServerCommand(userName, password, "MOVE 200 \"Checking 1\" \"Checking 1\"");
     AssertEqual(
         initialResponse
-            + "The debiting and crediting accounts are the same. Please try again."
+            + "FAIL: The debiting and crediting accounts are the same. Please try again."
             + System.lineSeparator(),
         outputString3);
 
@@ -459,7 +459,7 @@ public class ServerTestScenarios {
     String outputString4 =
         runServerCommand(userName, password, "MOVE -200 \"Saving 1\" \"Checking 1\"");
     AssertEqual(
-        initialResponse + "Amount is invalid. Please try again." + System.lineSeparator(),
+        initialResponse + "FAIL: Amount is invalid. Please try again." + System.lineSeparator(),
         outputString4);
 
     // Test 5
@@ -467,7 +467,7 @@ public class ServerTestScenarios {
         runServerCommand(userName, password, "MOVE /t \"Saving 1\" \"Checking 1\"");
     AssertEqual(
         initialResponse
-            + "Not enough arguments. Please try again."
+            + "FAIL: Not enough arguments. Please try again."
             + System.lineSeparator()
             + System.lineSeparator()
             + "MOVE "
@@ -479,7 +479,7 @@ public class ServerTestScenarios {
     String outputString6 = runServerCommand(userName, password, "MOVE \"Saving 1\" \"Checking 1\"");
     AssertEqual(
         initialResponse
-            + "Not enough arguments. Please try again."
+            + "FAIL: Not enough arguments. Please try again."
             + System.lineSeparator()
             + System.lineSeparator()
             + "MOVE "
@@ -495,7 +495,7 @@ public class ServerTestScenarios {
     String outputString = runServerCommand("John", "3", "MOVE 500.01 \"Saving 1\" \"Checking 1\"");
     AssertEqual(
         initialResponse
-            + "Not enough funds in account to be debited. Please try again."
+            + "FAIL: Not enough funds in account to be debited. Please try again."
             + System.lineSeparator(),
         outputString);
   }


### PR DESCRIPTION
Standardised error message centrally, so that any new response with status failed or invalid request starts with "FAIL:"
Consolidated cases for success messages
Modified test cases accordingly